### PR TITLE
Feat: Add global exception handler, Custom error code

### DIFF
--- a/src/main/java/com/example/ajoutayo/dto/StatusCode.java
+++ b/src/main/java/com/example/ajoutayo/dto/StatusCode.java
@@ -8,6 +8,7 @@ public class StatusCode {
     public static final int UNAUTHORIZED = 401;
     public static final int FORBIDDEN = 403;
     public static final int NOT_FOUND = 404;
+    public static final int METHOD_NOT_ALLOWED = 405;
     public static final int INTERNAL_SERVER_ERROR = 500;
     public static final int SERVICE_UNAVAILABLE = 503;
     public static final int DB_ERROR = 600;

--- a/src/main/java/com/example/ajoutayo/dto/response/ResponseMessage.java
+++ b/src/main/java/com/example/ajoutayo/dto/response/ResponseMessage.java
@@ -14,8 +14,6 @@ public class ResponseMessage {
     public static final String UPDATE_BOARD = "공지 수정 성공";
     public static final String DELETE_BOARD = "공지 삭제 성공";
     public static final String SEARCH_SUCCESS = "검색 성공";
-    public static final String INTERNAL_SERVER_ERROR = "서버 내부 에러";
-    public static final String DB_ERROR = "데이터베이스 에러";
 
 
 }

--- a/src/main/java/com/example/ajoutayo/exceptions/BoardErrorCode.java
+++ b/src/main/java/com/example/ajoutayo/exceptions/BoardErrorCode.java
@@ -1,0 +1,15 @@
+package com.example.ajoutayo.exceptions;
+
+import com.example.ajoutayo.dto.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BoardErrorCode implements ErrorCode {
+    BOARD_NOT_EXIST(HttpStatus.NOT_FOUND, "해당 게시물이 존재하지 않습니다.");
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/com/example/ajoutayo/exceptions/CommonErrorCode.java
+++ b/src/main/java/com/example/ajoutayo/exceptions/CommonErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.ajoutayo.exceptions;
+
+import com.example.ajoutayo.dto.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "Invalid request."),
+    UNAUTHORIZED_REQUEST(HttpStatus.UNAUTHORIZED, "Unauthorized."),
+    FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "Forbidden."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "Not found."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "Not allowed method."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Server error.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/ajoutayo/exceptions/CustomApiException.java
+++ b/src/main/java/com/example/ajoutayo/exceptions/CustomApiException.java
@@ -1,0 +1,10 @@
+package com.example.ajoutayo.exceptions;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomApiException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/example/ajoutayo/exceptions/ErrorCode.java
+++ b/src/main/java/com/example/ajoutayo/exceptions/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.example.ajoutayo.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/example/ajoutayo/exceptions/ErrorResponse.java
+++ b/src/main/java/com/example/ajoutayo/exceptions/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.example.ajoutayo.exceptions;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ErrorResponse {
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this.httpStatus = errorCode.getHttpStatus();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/example/ajoutayo/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/ajoutayo/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.example.ajoutayo.exceptions;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice // 전역 예외 처리
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+    /*
+     * Developer Custom Exception: 직접 정의한 RestApiException 에러 클래스에 대한 예외 처리
+     */
+    @ExceptionHandler(CustomApiException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(CustomApiException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    // handleExceptionInternal() 메소드를 오버라이딩해 응답 커스터마이징
+    private ResponseEntity<ErrorResponse> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity
+                .status(errorCode.getHttpStatus().value())
+                .body(new ErrorResponse(errorCode));
+    }
+}

--- a/src/main/java/com/example/ajoutayo/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/ajoutayo/service/BoardServiceImpl.java
@@ -6,6 +6,8 @@ import com.example.ajoutayo.domain.Board;
 import com.example.ajoutayo.dto.request.BoardCreateDto;
 import com.example.ajoutayo.dto.request.BoardUpdateDto;
 import com.example.ajoutayo.dto.response.BoardResponseDto;
+import com.example.ajoutayo.exceptions.BoardErrorCode;
+import com.example.ajoutayo.exceptions.CustomApiException;
 import com.example.ajoutayo.infrastructure.BoardRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +30,7 @@ public class BoardServiceImpl implements BoardService {
     @Transactional(readOnly = true)
     public BoardResponseDto getBoard(Long boardId) {
         Board board = boardRepository.findById(boardId).orElseThrow(()
-                -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
+                -> new CustomApiException(BoardErrorCode.BOARD_NOT_EXIST));
 
         return new BoardResponseDto(board);
     }
@@ -48,7 +50,7 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public BoardResponseDto updateBoard(Long boardId, BoardUpdateDto boardUpdateDto) {
         Board board = boardRepository.findById(boardId).orElseThrow(()
-                -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
+                -> new CustomApiException(BoardErrorCode.BOARD_NOT_EXIST));
 
         board.update(boardUpdateDto.getTitle(), boardUpdateDto.getContent());
         return new BoardResponseDto(board);
@@ -81,7 +83,7 @@ public class BoardServiceImpl implements BoardService {
         if (oldCookie != null) {
             if (!oldCookie.getValue().contains("[" + boardId.toString() + "]")) {
                 Board board = boardRepository.findById(boardId).orElseThrow(()
-                        -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
+                        -> new CustomApiException(BoardErrorCode.BOARD_NOT_EXIST));
                 board.viewCountUp(board);
 
                 oldCookie.setValue(oldCookie.getValue() + "_[" + boardId + "]");
@@ -91,7 +93,7 @@ public class BoardServiceImpl implements BoardService {
             }
         } else {
             Board board = boardRepository.findById(boardId).orElseThrow(()
-                    -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
+                    -> new CustomApiException(BoardErrorCode.BOARD_NOT_EXIST));
             board.viewCountUp(board);
 
             Cookie newCookie = new Cookie("boardView", "[" + boardId + "]");


### PR DESCRIPTION
* 참조
(1) https://velog.io/@u-nij/Spring-%EC%A0%84%EC%97%AD-%EC%98%88%EC%99%B8-%EC%B2%98%EB%A6%AC-RestControllerAdivce-%EC%A0%81%EC%9A%A9
(2) https://velog.io/@sorzzzzy/Spring-Boot5-9.-API-%EC%98%88%EC%99%B8%EC%B2%98%EB%A6%AC

* API의 각 오류 상황에 맞는 오류 응답 메시지 작성
* JSON으로 오류 응답 날리도록함